### PR TITLE
Fix Modals Height To Don't Truncate Content

### DIFF
--- a/src/components/PresetsModal.vue
+++ b/src/components/PresetsModal.vue
@@ -79,7 +79,14 @@ export default {
 <style lang="scss" scoped>
 @import '../styles/base';
 
+.modal-wrapper {
+  width: 80%;
+  height: 90%;
+}
+
 .presets-wrapper {
+  width: 100%;
+  height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
 }
@@ -87,9 +94,6 @@ export default {
 .preset-entry {
   cursor: pointer;
 
-  &:not(:last-child) {
-    border-bottom: $light-border;
-  }
   &:hover {
     background-color: rgba(255, 255, 255, 0.1);
   }

--- a/src/components/SavePresetModal.vue
+++ b/src/components/SavePresetModal.vue
@@ -2,9 +2,9 @@
     <transition name="modal" appear>
       <div class="modal-mask" @click="$emit('close')">
         <div class="modal-wrapper">
-          <div class="modal-container col" @click.stop>
+          <div class="modal-container" @click.stop>
             <h2>Save Preset</h2>
-            <div class="mx4 my2 row align-center justify-space-evenly">
+            <div class="preset-name-row-wrapper mx4 my2 row align-center justify-space-evenly">
               <div>
                 <img :src="img" alt="Preset Screenshot" v-if="img">
               </div>
@@ -68,8 +68,15 @@ export default {
 .modal-container {
   width: unset;
   height: unset;
-  max-width: 80%;
+  min-width: 80%;
+  max-width: 100%;
   max-height: 80%;
+}
+
+.preset-name-row-wrapper {
+  @include flexbox-centered;
+  flex-direction: row;
+  min-width: 80%;
 }
 
 img {

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -4,19 +4,29 @@
       <div class="modal-wrapper">
         <div class="modal-container col" @click.stop>
           <h2>Settings</h2>
-          <div class="settings-wrap">
-            <div class="row align-start settings-section">
-              <span class="mr3">Mousewheel Sensitivity:</span>
-              <div class="col">
+          <div class="settings-table">
+            <div class="settings-line">
+              <span class="settings-cell mr3">Mousewheel Sensitivity:</span>
+              <div class="settings-cell slider-and-labels-wrapper">
                 <Slider :min="0" :max="9" :step="1" v-model="sensitivity" orient="horizontal" />
-                <div class="row grow justify-space-between mt1">
+                <div class="row justify-space-between mt1">
+                  <small>Less</small>
+                  <small>More</small>
+                </div>
+              </div>
+            </div>
+            <div class="settings-line">
+              <span class="settings-cell mr3">Mousewheel Sensitivity  dfasfdsafsdfasfewrwer:</span>
+              <div class="settings-cell slider-and-labels-wrapper">
+                <Slider :min="0" :max="9" :step="1" v-model="sensitivity" orient="horizontal" />
+                <div class="row justify-space-between mt1">
                   <small>Less</small>
                   <small>More</small>
                 </div>
               </div>
             </div>
           </div>
-          <div class="col grow justify-flex-end align-center">
+          <div class="col grow justify-center align-center">
             <button @click="$emit('close')">Close</button>
           </div>
         </div>
@@ -56,10 +66,34 @@ export default {
 <style lang="scss" scoped>
 @import '../styles/base';
 
-.settings-section {
+.modal-container {
+  width: unset;
+  height: unset;
+  min-width: 80%;
+  max-width: 100%;
+  max-height: 80%;
+}
+
+.settings-table {
+  width: 100%;
   padding: 12px 24px;
-  &:not(:last-child) {
-    border-bottom: $light-border;
+  display: table;
+}
+
+.settings-line {
+  display: table-row;
+}
+
+.settings-cell {
+  display: table-cell;
+  padding: 6px 0;
+}
+
+.slider-and-labels-wrapper {
+  @include flexbox-centered;
+  & > * {
+    width: 100%;
   }
 }
+
 </style>

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -36,7 +36,7 @@ export default {
 <style lang="scss" scoped>
 @import '../styles/base';
 
-$track-w: 128px;
+$track-w: 100%;
 $track-h: 4px;
 $thumb-d: 12px;
 

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -10,9 +10,14 @@
 @mixin hover-shadow {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.13), 1px 2px 3px rgba(0, 0, 0, .1), -1px -2px 3px rgba(0, 0, 0, .05);
 }
+@mixin flexbox-centered {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
 
 $separator: 1px solid rgba(0, 0, 0, 0.2);
 $border: 1px solid rgba(255, 255, 255, 0.7);
-$light-border: 1px solid rgba(255, 255, 255, 0.2);
 $standard-border-radius: 4px;
 $bezier-transition: 0.3s cubic-bezier(0, 0, 0.24, 1);

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -7,22 +7,23 @@
   left: 0;
   width: 100%;
   height: 100%;
+  @include flexbox-centered;
   background-color: rgba(0, 0, 0, 0.8);
-  display: table;
   transition: opacity .3s ease;
 }
 
 .modal-wrapper {
-  display: table-cell;
-  vertical-align: middle;
+  width: 100%;
+  height: 100%;
+  @include flexbox-centered;
 }
 
 .modal-container {
-  width: 80%;
-  height: 80%;
-  max-height: 80%;
+  width: 100%;
+  height: 100%;
   margin: 0 auto;
   padding: 12px;
+  @include flexbox-centered;
   background-color: $section-color;
   border-radius: 4px;
   transition: $bezier-transition;


### PR DESCRIPTION
fix(_modal.scss): height of all modals not to be larger than 100%, so don't truncate content.

Layout is almost the same.

<details>
<summary>Before: presets were truncated</summary>

![Screenshot from 2022-04-10 05-11-02](https://user-images.githubusercontent.com/12682937/162599553-60d1c958-443f-4ef4-a39d-fef63aa6bfee.png)
</details>

<details>
<summary>After: fixed truncating presets</summary>

![Screenshot from 2022-04-10 05-48-21](https://user-images.githubusercontent.com/12682937/162599573-ce311dee-b7fe-41f3-a5b3-9122dc1c3d6e.png)
</details>

<details>
<summary>Before: save preset</summary>

![Screenshot from 2022-04-10 05-10-50](https://user-images.githubusercontent.com/12682937/162599589-85767efb-615b-4ff2-a70d-b549bee000ee.png)
</details>

<details>
<summary>After: save preset</summary>

![Screenshot from 2022-04-10 05-11-16](https://user-images.githubusercontent.com/12682937/162599604-6ce815d9-9a65-40a0-a414-1260cdda4829.png)
</details>

<details>
<summary>Before: settings</summary>

![Screenshot from 2022-04-10 05-11-09](https://user-images.githubusercontent.com/12682937/162599621-1245cd39-bd16-4a10-bfa4-29917bd57ead.png)
</details>

<details>
<summary>After: settings</summary>

![Screenshot from 2022-04-10 05-34-06](https://user-images.githubusercontent.com/12682937/162599629-ddefc98d-216a-4bf9-a169-ee9b68c882ab.png)
</details>

<details>
<summary>After: settings (change to table, so new ones will be aligned)</summary>

![Screenshot from 2022-04-10 05-33-28](https://user-images.githubusercontent.com/12682937/162599649-81487802-ec3a-4a26-9cce-b4a8b31d80f9.png)
</details>